### PR TITLE
Clean up the IPlayer interface

### DIFF
--- a/src/model/IPlayer.cs
+++ b/src/model/IPlayer.cs
@@ -4,8 +4,6 @@
 
 namespace MusicSharp
 {
-    using NAudio.Wave;
-
     /// <summary>
     /// Defines the methods an audio player class should implement.
     /// </summary>
@@ -15,16 +13,6 @@ namespace MusicSharp
         /// Gets or sets the last file opened by the player.
         /// </summary>
         string LastFileOpened { get; set; }
-
-        /// <summary>
-        /// Gets or sets the audio output device.
-        /// </summary>
-        WaveOutEvent OutputDevice { get; set; }
-
-        /// <summary>
-        /// Gets or sets the audio file to load.
-        /// </summary>
-        AudioFileReader AudioFile { get; set; }
 
         /// <summary>
         /// Method to play audio.
@@ -41,12 +29,5 @@ namespace MusicSharp
         /// Method to stop audio playback.
         /// </summary>
         void Stop();
-
-        /// <summary>
-        /// Method to dispose of resources when audio playback is finished.
-        /// </summary>
-        /// <param name="sender">The object.</param>
-        /// <param name="args">StoppedEventArgs.</param>
-        void OnPlaybackStopped(object sender, StoppedEventArgs args);
     }
 }

--- a/src/view/Gui.cs
+++ b/src/view/Gui.cs
@@ -76,20 +76,12 @@ namespace MusicSharp
             var playBtn = new Button(1, 1, "Play");
             playBtn.Clicked += () =>
             {
-                if (this.player.LastFileOpened != null && this.player.OutputDevice != null)
-                {
-                    try
-                    {
-                        this.player.OutputDevice.Play();
-                    }
-                    catch (System.NullReferenceException)
-                    {
-                    }
-                }
-                else
-                {
+                if(this.player.LastFileOpened == null) {
                     this.OpenFile();
+                    return;
                 }
+
+                this.player.Play(this.player.LastFileOpened);
             };
 
             var pauseBtn = new Button(10, 1, "Pause");
@@ -169,7 +161,7 @@ namespace MusicSharp
             if (!d.Canceled)
             {
                 this.player.LastFileOpened = d.FilePath.ToString();
-                this.player.Play(d.FilePath.ToString());
+                this.player.Play(this.player.LastFileOpened);
             }
         }
     }


### PR DESCRIPTION
Clean up the IPlayer interface to be loosely coupled to the implementation. This opens up reusing the interface for usage in other implementations not coupled to the NAudio package.