### PR TITLE
Fix #8: Linux player implementation

### DIFF
--- a/MusicSharpTests/LinuxPlayerTests.cs
+++ b/MusicSharpTests/LinuxPlayerTests.cs
@@ -1,0 +1,107 @@
+using MusicSharp.SoundEngines;
+using MusicSharp.Enums;
+
+namespace MusicSharpTests;
+
+[TestFixture]
+public class LinuxPlayerTests
+{
+    private LinuxPlayer _player;
+    private const string ValidFilePath = "test.mp3";
+    private const string ValidStreamUrl = "https://example.com/stream";
+
+    [SetUp]
+    public void Setup()
+    {
+        // Create test file
+        File.WriteAllText(ValidFilePath, "dummy content");
+        _player = new LinuxPlayer();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (File.Exists(ValidFilePath))
+            File.Delete(ValidFilePath);
+
+        // Ensure player is stopped after each test
+        _player.Stop();
+    }
+
+    [Test]
+    public void OpenFile_WithInvalidPath_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() => _player.OpenFile("nonexistent.mp3"));
+    }
+
+    [Test]
+    public void OpenFile_WithValidPath_UpdatesPlayerStatus()
+    {
+        // Act
+        _player.OpenFile(ValidFilePath);
+
+        Assert.Multiple(() =>
+        {
+            // Assert
+            Assert.That(_player.PlayerStatus, Is.EqualTo(ePlayerStatus.Playing));
+            Assert.That(_player.LastFileOpened, Does.Contain(ValidFilePath));
+        });
+    }
+
+    [Test]
+    public void OpenStream_UpdatesLastFileOpened()
+    {
+        // Act
+        _player.OpenStream(ValidStreamUrl);
+
+        // Assert
+        Assert.That(_player.LastFileOpened, Is.EqualTo(ValidStreamUrl));
+    }
+
+    [Test]
+    public void Stop_SetsCorrectPlayerStatus()
+    {
+        // Arrange
+        _player.OpenFile(ValidFilePath);
+
+        // Act
+        _player.Stop();
+
+        // Assert
+        Assert.That(_player.PlayerStatus, Is.EqualTo(ePlayerStatus.Stopped));
+    }
+
+    [Test]
+    public void CurrentTime_WhenStopped_ReturnsZero()
+    {
+        // Act
+        var result = _player.CurrentTime();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void TrackLength_WhenStopped_ReturnsZero()
+    {
+        // Act
+        var result = _player.TrackLength();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void PlayFromPlaylist_WithValidPath_UpdatesPlayerStatus()
+    {
+        // Act
+        _player.PlayFromPlaylist(ValidFilePath);
+
+        Assert.Multiple(() =>
+        {
+            // Assert
+            Assert.That(_player.PlayerStatus, Is.EqualTo(ePlayerStatus.Playing));
+            Assert.That(_player.LastFileOpened, Does.Contain(ValidFilePath));
+        });
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,11 +19,24 @@ Currently in beta, MusicSharp makes use of the [NAudio](https://github.com/naudi
 ## Planned
 
 - Save playlists.
-- Cross platform support.
+- Cross-platform support.
 
 ## Installation
 
 Download the [latest release of MusicSharp](https://github.com/markjamesm/MusicSharp/releases) and follow the installation instructions.
+
+### Additional step for Linux
+
+Install GStreamer:
+```bash
+# Ubuntu/Debian:
+sudo apt-get install gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+```
+
+```bash 
+# Fedora
+sudo dnf install gstreamer1-plugins-base gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free
+```
 
 ## Want to Contribute?
 

--- a/src/MusicSharp.csproj
+++ b/src/MusicSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.4.9</Version>
+    <Version>0.5.9</Version>
     <Authors>Mark-James McDougall</Authors>
     <Company>Mark-James McDougall</Company>
     <PackageIcon></PackageIcon>
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="gstreamer-sharp-netcore" Version="0.0.8" />
     <PackageReference Include="NAudio" Version="1.10.0" />
     <PackageReference Include="Terminal.Gui" Version="0.90.3" />
     <PackageReference Include="z440.atl.core" Version="3.13.0" />

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,6 +2,8 @@
 // Licensed under the GNU GPL v3 License. See LICENSE in the project root for license information.
 // </copyright>
 
+using System;
+using System.Runtime.InteropServices;
 using MusicSharp.SoundEngines;
 using MusicSharp.View;
 
@@ -15,7 +17,21 @@ public static class Program
     /// </summary>
     public static void Main()
     {
-        var player = new WinPlayer();
+        IPlayer player;
+
+        if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            player = new WinPlayer();
+        }
+        else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            player = new LinuxPlayer();
+        }
+        else
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         var gui = new Tui(player);
 
         gui.Start();

--- a/src/SoundEngines/LinuxPlayer.cs
+++ b/src/SoundEngines/LinuxPlayer.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using MusicSharp.Enums;
+using Gst;
+
+namespace MusicSharp.SoundEngines;
+
+/// <summary>
+/// The audio player implementation for Linux based systems using GStreamer.
+/// </summary>
+public class LinuxPlayer : IPlayer
+{
+    public ePlayerStatus PlayerStatus { get; set; }
+    public string LastFileOpened { get; set; }
+
+    private readonly Element _playbin;
+    private readonly Pipeline _pipeline;
+    private double _currentVolume = 1.0; // Start at 100% volume
+    private const double VolumeStep = 0.1; // 10% volume change per step
+
+    public LinuxPlayer()
+    {
+        Application.Init();
+
+        _playbin = ElementFactory.Make("playbin", "player");
+        _pipeline = new Pipeline("pipeline");
+        _pipeline.Add(_playbin);
+    }
+
+    /// <inheritdoc/>
+    public void OpenFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("File not found", path);
+        }
+
+        var uri = new System.Uri(new FileInfo(path).FullName).ToString();
+        PlayUri(uri);
+    }
+
+    private void PlayUri(string uri)
+    {
+        _pipeline.SetState(State.Null);
+        _playbin["uri"] = uri;
+
+        var stateChangeReturn = _pipeline.SetState(State.Playing);
+        if (stateChangeReturn is StateChangeReturn.Failure)
+        {
+            _pipeline.SetState(State.Null);
+            throw new InvalidOperationException("Failed to play the media");
+        }
+
+        LastFileOpened = uri;
+        PlayerStatus = ePlayerStatus.Playing;
+    }
+
+    /// <inheritdoc/>
+    public void OpenStream(string streamUrl)
+    {
+        PlayUri(streamUrl);
+    }
+
+    /// <inheritdoc/>
+    public void PlayPause()
+    {
+        switch (_pipeline.CurrentState)
+        {
+            case State.Playing:
+                _pipeline.SetState(State.Paused);
+                break;
+
+            case State.Paused:
+            case State.Null:
+            case State.VoidPending:
+            case State.Ready:
+                _pipeline.SetState(State.Playing);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Stop()
+    {
+        _pipeline.SetState(State.Null);
+        _playbin["uri"] = string.Empty;
+        PlayerStatus = ePlayerStatus.Stopped;
+    }
+
+    /// <inheritdoc/>
+    public void IncreaseVolume()
+    {
+        _currentVolume = Math.Min(_currentVolume + VolumeStep, 1.0);
+        _playbin["volume"] = _currentVolume;
+    }
+
+    /// <inheritdoc/>
+    public void DecreaseVolume()
+    {
+        _currentVolume = Math.Max(_currentVolume - VolumeStep, 0.0);
+        _playbin["volume"] = _currentVolume;
+    }
+
+    /// <inheritdoc/>
+    public void PlayFromPlaylist(string path)
+    {
+        // Watching the WinPlayer implementation of this method I get that it is a placeholder for the future ?
+        // I am forwarding the call to the OpenFile method to avoid putting a NotImplementedException and crashing the app.
+        OpenFile(path);
+    }
+
+    /// <inheritdoc/>
+    public TimeSpan CurrentTime()
+    {
+        if (_pipeline is null || PlayerStatus is ePlayerStatus.Stopped)
+        {
+            return TimeSpan.Zero;
+        }
+
+        // Query the current position in nanoseconds
+        _pipeline.QueryPosition(Format.Time, out var position);
+
+        // Convert from nanoseconds to TimeSpan
+        // GStreamer uses nanoseconds (1 second = 1,000,000,000 nanoseconds)
+        return TimeSpan.FromMilliseconds(position / 1_000_000.0);
+    }
+
+    /// <inheritdoc/>
+    public TimeSpan TrackLength()
+    {
+        if (_pipeline is null || PlayerStatus is ePlayerStatus.Stopped)
+        {
+            return TimeSpan.Zero;
+        }
+
+        // Query the duration in nanoseconds
+        _pipeline.QueryDuration(Format.Time, out var duration);
+
+        // Convert from nanoseconds to TimeSpan
+        // GStreamer uses nanoseconds (1 second = 1,000,000,000 nanoseconds)
+        return TimeSpan.FromMilliseconds(duration / 1_000_000.0);
+    }
+
+    /// <inheritdoc/>
+    public void SeekForward()
+    {
+        SeekTime(true);
+    }
+
+    /// <inheritdoc/>
+    public void SeekBackwards()
+    {
+        SeekTime(false);
+    }
+
+    private void SeekTime(bool isForward)
+    {
+        if (_pipeline is null || PlayerStatus is ePlayerStatus.Stopped || IsStream())
+        {
+            return;
+        }
+
+        _pipeline.QueryPosition(Format.Time, out var position);
+        _pipeline.QueryDuration(Format.Time, out var duration);
+
+        long newPosition;
+
+        if (isForward)
+        {
+            newPosition = position + (5 * 1_000_000_000L);
+            newPosition = Math.Min(newPosition, duration);
+        }
+        else
+        {
+            newPosition = position - (5 * 1_000_000_000L);
+            newPosition = Math.Max(newPosition, 0);
+        }
+
+        _pipeline.SeekSimple(
+            Format.Time,
+            SeekFlags.Flush | SeekFlags.KeyUnit,
+            newPosition
+        );
+    }
+
+    private bool IsStream()
+    {
+        return LastFileOpened.StartsWith("http") || LastFileOpened.StartsWith("https");
+    }
+}


### PR DESCRIPTION
Hi there,

I implemented a Linux player, and tested it on Pop!_OS.
Since libsndfile still doesn't support mp3, I used GStreamer, which does add a dependency sadly.

The player is fully functional except for the playlist feature.

The choice of player is made on the at the startup.

I added the dependencies install instruction in the README.md.

Note:
I didn't test this implementation on Windows yet. It shouldn't break anything as the player choice is made based on the Running OS. It isn't impossible that this implementation is working on Windows too.